### PR TITLE
getAdaptedHost: allow consumer on localhost to control model host using subdomain

### DIFF
--- a/src/model/utils/getAdaptedHost.js
+++ b/src/model/utils/getAdaptedHost.js
@@ -4,5 +4,5 @@
  */
 export const getAdaptedHost = host =>
   host.indexOf('localhost:') !== -1
-    ? 'npreview-mos-eisley.lodgifyintegration.com'
+    ? host.replace(/localhost:\d{4}/, 'lodgifyintegration.com')
     : host;

--- a/src/model/utils/getAdaptedHost.spec.js
+++ b/src/model/utils/getAdaptedHost.spec.js
@@ -1,19 +1,19 @@
 import { getAdaptedHost } from './getAdaptedHost';
 
 describe('utils/getAdaptedHost', () => {
-  it('should return the correct host for localhost', () => {
-    const host = 'localhost:5050';
+  describe('if `host` includes `localhost:`', () => {
+    it('should return the right string', () => {
+      const actual = getAdaptedHost('something.localhost:8080');
 
-    const actual = getAdaptedHost(host);
-
-    expect(actual).toBe('npreview-mos-eisley.lodgifyintegration.com');
+      expect(actual).toBe('something.lodgifyintegration.com');
+    });
   });
 
-  it('should return the correct host if not localhost', () => {
-    const host = 'npreview-julio-x-livingstone-2.lodgifystaging.com';
+  describe('if `host` does not include `localhost:`', () => {
+    it('should return the right string', () => {
+      const actual = getAdaptedHost('something.lodgify.com');
 
-    const actual = getAdaptedHost(host);
-
-    expect(actual).toBe('npreview-julio-x-livingstone-2.lodgifystaging.com');
+      expect(actual).toBe('something.lodgify.com');
+    });
   });
 });


### PR DESCRIPTION
### What **one** thing does this PR do?
`getAdaptedHost`: allow consumer on localhost to control model host using subdomain

#### Example usage running websites on `localhost`...

![Screenshot 2019-04-30 at 12 39 34](https://user-images.githubusercontent.com/8591501/56956652-11f9a680-6b45-11e9-8eb3-9980cd818902.png)


