### PR TITLE
TE-2191 Model: accept cookie parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,16 @@ const localization = getLocalization();
 
 ### postModel
 ```js
-import { getLocalization } from '@lodgify/website-service-client';
+import { postModel } from '@lodgify/website-service-client';
 
 const host = 'someHost';
 const path = 'someUrl';
+const cookie = 'cookie=somevalue;';
 
-getLocalization(
+postModel(
   host,
-  path
+  path,
+  cookie
 );
 ```
 

--- a/src/model/post.js
+++ b/src/model/post.js
@@ -10,15 +10,20 @@ import { getAdaptedHost } from './utils/getAdaptedHost';
 /**
  * @param  {string} host
  * @param  {string} path
+ * @param  {string} cookie
  * @return {Promise}
  */
-export const post = (host, path) => {
+export const post = (host, path, cookie) => {
   const url = getUrl(ORIGIN, PATHNAME);
   const adaptedPath = getAdaptedPath(path);
   const adaptedHost = getAdaptedHost(host);
 
-  return postJSON(url, {
-    host: adaptedHost,
-    path: adaptedPath,
-  });
+  return postJSON(
+    url,
+    {
+      host: adaptedHost,
+      path: adaptedPath,
+    },
+    { Cookie: cookie }
+  );
 };

--- a/src/model/post.spec.js
+++ b/src/model/post.spec.js
@@ -20,6 +20,7 @@ const { post } = require('./post');
 
 const host = 'someHost';
 const path = 'someUrl';
+const cookie = 'someCookie';
 
 const URL = 'URL';
 const ADAPTED_PATH = 'ADAPTED_PATH';
@@ -31,7 +32,7 @@ getAdaptedHost.mockImplementation(() => ADAPTED_HOST);
 
 describe(`${PATHNAME}/post`, () => {
   beforeAll(() => {
-    post(host, path);
+    post(host, path, cookie);
   });
 
   it('should call `getUrl` with the correct arguments', () => {
@@ -47,10 +48,16 @@ describe(`${PATHNAME}/post`, () => {
   });
 
   it('should call `postJSON` with the correct arguments', () => {
-    expect(postJSON).toHaveBeenCalledWith(URL, {
-      host: ADAPTED_HOST,
-      path: ADAPTED_PATH,
-    });
+    expect(postJSON).toHaveBeenCalledWith(
+      URL,
+      {
+        host: ADAPTED_HOST,
+        path: ADAPTED_PATH,
+      },
+      {
+        Cookie: cookie,
+      }
+    );
   });
 
   it('should return whatever `postJSON` returns', () => {


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2191)

### What **one** thing does this PR do?
`postModel` accepts a cookie parameter and passes as a header to `postJSON`

